### PR TITLE
Add discovering services in example

### DIFF
--- a/example/config.make
+++ b/example/config.make
@@ -88,7 +88,7 @@
 # add a runtime path to search for those shared libraries, since they aren't 
 # incorporated directly into the final executable application binary.
 # TODO: should this be a default setting?
-PROJECT_LDFLAGS=-lz -L /lib64 -l avahi-client -lavahi-common
+PROJECT_LDFLAGS = -Wl,-rpath=./libs
 
 ################################################################################
 # PROJECT DEFINES

--- a/example/config.make
+++ b/example/config.make
@@ -88,7 +88,7 @@
 # add a runtime path to search for those shared libraries, since they aren't 
 # incorporated directly into the final executable application binary.
 # TODO: should this be a default setting?
-# PROJECT_LDFLAGS=-Wl,-rpath=./libs
+PROJECT_LDFLAGS=-lz -L /lib64 -l avahi-client -lavahi-common
 
 ################################################################################
 # PROJECT DEFINES

--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -4,6 +4,15 @@
 void testApp::setup(){
 	// start a test service
 	service.start("Test Service!", "_http._tcp", 8080);
+  // look for a service
+  browser.lookup("_http._tcp");
+  ofAddListener(browser.serviceNewE, this, &testApp::onService);
+}
+
+//--------------------------------------------------------------
+void testApp::onService(ofxAvahiService &s){
+  ofLogNotice("on service");
+
 }
 
 //--------------------------------------------------------------

--- a/example/src/testApp.cpp
+++ b/example/src/testApp.cpp
@@ -6,12 +6,18 @@ void testApp::setup(){
 	service.start("Test Service!", "_http._tcp", 8080);
   // look for a service
   browser.lookup("_http._tcp");
-  ofAddListener(browser.serviceNewE, this, &testApp::onService);
+  ofAddListener(browser.serviceNewE, this, &testApp::onServiceNew);
+  ofAddListener(browser.serviceRemoveE, this, &testApp::onServiceRemove);
 }
 
 //--------------------------------------------------------------
-void testApp::onService(ofxAvahiService &s){
-  ofLogNotice("on service");
+void testApp::onServiceNew(ofxAvahiService &s){
+  ofLogNotice("Found service:" + s.name + " | " + s.host_name + " | " + s.domain + " | " + s.ip + " | " + ofToString(s.port));
+}
+
+//--------------------------------------------------------------
+void testApp::onServiceRemove(ofxAvahiService &s){
+  ofLogNotice("Service went down:" + s.name + " | " + s.host_name + " | " + s.domain + " | " + s.ip + " | " + ofToString(s.port));
 
 }
 

--- a/example/src/testApp.h
+++ b/example/src/testApp.h
@@ -19,6 +19,8 @@ class testApp : public ofBaseApp{
 		void windowResized(int w, int h);
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
+    void onService(ofxAvahiService &s);
 
 		ofxAvahiClientService service;
+		ofxAvahiClientBrowser browser;
 };

--- a/example/src/testApp.h
+++ b/example/src/testApp.h
@@ -19,7 +19,8 @@ class testApp : public ofBaseApp{
 		void windowResized(int w, int h);
 		void dragEvent(ofDragInfo dragInfo);
 		void gotMessage(ofMessage msg);
-    void onService(ofxAvahiService &s);
+    void onServiceNew(ofxAvahiService &s);
+    void onServiceRemove(ofxAvahiService &s);
 
 		ofxAvahiClientService service;
 		ofxAvahiClientBrowser browser;

--- a/src/ofxAvahiClientBrowser.h
+++ b/src/ofxAvahiClientBrowser.h
@@ -32,6 +32,7 @@ public:
 
 protected:
 	void threadedFunction();
+  static ofMutex mutex;
 
 private:
 	AvahiClient * client;


### PR DESCRIPTION
In the example, it showed how to publish a service but not how to lookup for one.
Fixed now with these commits.
