### PR TITLE
Fixed startthread function calls

### DIFF
--- a/src/ofxAvahiClientBrowser.cpp
+++ b/src/ofxAvahiClientBrowser.cpp
@@ -97,7 +97,7 @@ bool ofxAvahiClientBrowser::lookup(const string& type){
 
 	avahi_service_browser_new(client,AVAHI_IF_UNSPEC,AVAHI_PROTO_INET,type.c_str(),NULL,(AvahiLookupFlags)0,(AvahiServiceBrowserCallback)service_browser_cb,this);
 
-	startThread(true,false);
+	startThread(true);
 
 	return true;
 }

--- a/src/ofxAvahiClientService.cpp
+++ b/src/ofxAvahiClientService.cpp
@@ -156,7 +156,7 @@ bool ofxAvahiClientService::start(const string& service_name, const string& _typ
         (AvahiTimeoutCallback)&modify_cb,
         this);*/
 
-	startThread(true,false);
+	startThread(true);
 
     return true;
 }


### PR DESCRIPTION
startthread calls were broken by the following commit:

https://github.com/openframeworks/openFrameworks/commit/3fd132d02ce664c867b7f65bddb4dd1fa8e61be4
